### PR TITLE
fixed the hide/show issue. Read message on pull request for more info

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -26,11 +26,11 @@
                 <section class="form-group row">
                     <label for="exampleFormControlTextarea1" class="font-weight-bold col-md-2 col-sm-3">Description:</label>
                     <textarea class="form-control col-md-10 col-sm-9" id="description" placeholder="Description" rows="3" maxlength="150" minlength="1" required></textarea>
-                    <div id="descriptionAlert" class="alert alert-warning alert-dismissible fade" role="alert" aria-hidden="true">
+                    <div id="descriptionAlert" class="alert-warning fade hide" role="alert" aria-hidden="true">
                         <strong>Holy guacamole!</strong> You should check in on some of those fields below.
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <!-- <button type="button" id="closeDescriptionAlert" data-dismiss="alert" aria-label="Close">
                           <span aria-hidden="true">&times;</span>
-                        </button>
+                        </button> -->
                       </div>
                 </section>
                 <!--Create an Assigned to label and input field-->

--- a/js/index.js
+++ b/js/index.js
@@ -7,6 +7,8 @@ const dueDate = document.getElementById("dueDate");
 const status = document.getElementById("status");
 const statusValue = status.value;
 const email = document.getElementById("email");
+const closeDescriptionAlert = document.getElementById("closeDescriptionAlert");
+const descriptionAlert = document.getElementById("descriptionAlert");
 
 // Create a function to return the HTML for each individual task
 const createTaskHtml = (name, description, assignedTo, dueDate, statusValue, email) => {
@@ -57,23 +59,30 @@ const createTaskHtml = (name, description, assignedTo, dueDate, statusValue, ema
 // const taskHtml = createTaskHtml('Person1','clean','Person2','07/08/2021','Todo', 'person@gmail.com');
 // console.log(taskHtml);
 
+const toggleShowAlert = () => {
+    
+}
+
 const validFormFieldInput = (data) => {
-    console.log(document.getElementById("descriptionAlert").classList);
    if (data.length < 1) {
-    //    alert("Please, put enter a description.");
-    let element = document.getElementById("descriptionAlert");
-    if (element.classList[4] === "hide") {
-    element.classList.remove("hide");
-    element.classList.add("show");
-    }
-    element.classList.remove("show");
-    element.classList.add("hide");
+    descriptionAlert.classList.remove("hide");
+    descriptionAlert.classList.add("show");
+    setTimeout(()=>{
+        descriptionAlert.classList.remove("show");
+        descriptionAlert.classList.add("hide");
+    }, 3000)
+    
     return false;
     }else {
         return true;
     }
 }
 
+// You can comment this (lines 82-85 below) back in and then when you click the "X" on the alert it will go away, make sure to comment out the "setTimeout" function (lines 70 - 73 above) and uncomment the "button" associated with it as well (lines 31-33 in index.html) if you want to change the way the message is closed out. Currently it will show for 3 seconds. But you can make those changes so it stays until the user closes them if you want.
+// closeDescriptionAlert.addEventListener("click", function(){
+//     descriptionAlert.classList.remove("show");
+//     descriptionAlert.classList.add("hide");
+// })
 
 save.addEventListener('click', function(event) {
     event.preventDefault();


### PR DESCRIPTION
The reason what we were doing before wasn't working was because there was a "class" on the alert box that removed it from the DOM after being clicked. The class is "alert". So if you decide to use more of these make sure to remove the class="alert" from the list of classes. 

Please read line 81 of the index.js for directions on how you can choose to use the alert box. I currently have it set to timeout after 3 seconds, but you can make changes I have written on line 81 in index.js to make it so it doesn't time out and the user has to delete it.